### PR TITLE
gfx: Make a preliminary port of WebRender to the Mac.

### DIFF
--- a/components/gfx/font_template.rs
+++ b/components/gfx/font_template.rs
@@ -170,7 +170,7 @@ impl FontTemplate {
         let template_data = Arc::new(FontTemplateData::new(self.identifier.clone(), None));
 
         if let Some(ref webrender_api) = self.webrender_api {
-            webrender_api.add_font(self.identifier.clone(), template_data.bytes.clone());
+            webrender_api.add_font(self.identifier.clone(), template_data.bytes());
         }
 
         self.weak_ref = Some(Arc::downgrade(&template_data));

--- a/components/gfx/platform/freetype/font_template.rs
+++ b/components/gfx/platform/freetype/font_template.rs
@@ -36,4 +36,10 @@ impl FontTemplateData {
             identifier: identifier,
         }
     }
+
+    /// Returns a clone of the data in this font. This is a hugely expensive operation which
+    /// performs synchronous disk I/O and should never be done lightly.
+    pub fn bytes(&self) -> Vec<u8> {
+        self.bytes.clone()
+    }
 }

--- a/components/gfx/platform/macos/font_template.rs
+++ b/components/gfx/platform/macos/font_template.rs
@@ -9,9 +9,12 @@ use core_text::font::CTFont;
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::ToOwned;
+use std::fs::File;
+use std::io::Read;
 use std::ops::Deref;
 use std::sync::Mutex;
 use string_cache::Atom;
+use url::Url;
 
 /// Platform specific font representation for mac.
 /// The identifier is a PostScript font name. The
@@ -61,6 +64,23 @@ impl FontTemplateData {
             }
         }
         ctfont.as_ref().map(|ctfont| (*ctfont).clone())
+    }
+
+    /// Returns a clone of the data in this font. This is a hugely expensive operation which
+    /// performs synchronous disk I/O and should never be done lightly.
+    pub fn bytes(&self) -> Vec<u8> {
+        let path =
+            Url::parse(&*self.ctfont()
+                             .expect("No Core Text font available!")
+                             .url()
+                             .expect("No URL for Core Text font!")
+                             .get_string()
+                             .to_string()).expect("Couldn't parse Core Text font URL!")
+                                          .to_file_path()
+                                          .expect("Core Text font didn't name a path!");
+        let mut bytes = Vec::new();
+        File::open(path).expect("Couldn't open font file!").read_to_end(&mut bytes).unwrap();
+        bytes
     }
 }
 


### PR DESCRIPTION
We still use FreeType, which is inconsistent with the OS font
rasterization; perhaps we should switch to native Core Graphics
rasterization. Anyway, this works for now and we have more important
things to fix.

Depends on glennw/webrender#2.

r? @glennw
