### PR TITLE
compositor: Batch scroll events up into one before rendering with WebRender.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1145,18 +1145,34 @@ impl<Window: WindowMethods> IOCompositor<Window> {
 
     fn process_pending_scroll_events(&mut self) {
         let had_scroll_events = self.pending_scroll_events.len() > 0;
-        for scroll_event in std_mem::replace(&mut self.pending_scroll_events,
-                                             Vec::new()) {
-            let delta = scroll_event.delta / self.scene.scale;
-            let cursor = scroll_event.cursor.as_f32() / self.scene.scale;
-
-            if let Some(ref webrender_api) = self.webrender_api {
-                webrender_api.scroll(delta.to_untyped());
-            } else if let Some(ref mut layer) = self.scene.root {
-                layer.handle_scroll_event(delta, cursor);
+        match self.webrender_api {
+            Some(ref webrender_api) => {
+                // Batch up all scroll events into one, or else we'll do way too much painting.
+                let mut total_delta = None;
+                for scroll_event in std_mem::replace(&mut self.pending_scroll_events, vec![]) {
+                    let this_delta = scroll_event.delta / self.scene.scale;
+                    match total_delta {
+                        None => total_delta = Some(this_delta),
+                        Some(ref mut total_delta) => *total_delta = *total_delta + this_delta,
+                    }
+                }
+                if let Some(total_delta) = total_delta {
+                    webrender_api.scroll(total_delta.to_untyped());
+                }
             }
+            None => {
+                for scroll_event in std_mem::replace(&mut self.pending_scroll_events,
+                                                     Vec::new()) {
+                    let delta = scroll_event.delta / self.scene.scale;
+                    let cursor = scroll_event.cursor.as_f32() / self.scene.scale;
 
-            self.perform_updates_after_scroll();
+                    if let Some(ref mut layer) = self.scene.root {
+                        layer.handle_scroll_event(delta, cursor);
+                    }
+
+                    self.perform_updates_after_scroll();
+                }
+            }
         }
 
         if had_scroll_events {

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -148,9 +148,12 @@ impl Browser {
         let (webrender, webrender_api) = if opts::get().use_webrender {
             let resource_path = resources_dir_path();
             let size = opts::get().initial_window_size.to_untyped();
+            let device_pixel_ratio =
+                window.as_ref().map(|window| window.hidpi_factor().get()).unwrap_or(1.0);
             let webrender = webrender::Renderer::new(render_notifier,
                                                      size.width,
                                                      size.height,
+                                                     device_pixel_ratio,
                                                      resource_path);
             let webrender_api = webrender.new_api();
             (Some(webrender), Some(webrender_api))


### PR DESCRIPTION
On the Mac, it's often the case that multiple scroll events are
delivered per frame. Batching them up avoids drawing lots of frames that
are never shown.
