### PR TITLE
Add support for packed stretch_rect in ps_image shader

### DIFF
--- a/resources/shaders/ps_image.fs.glsl
+++ b/resources/shaders/ps_image.fs.glsl
@@ -3,5 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 void main(void) {
-    oFragColor = texture(sDiffuse, vUv);
+    vec2 st = vTextureOffset + vTextureSize * fract(vUv);
+    oFragColor = texture(sDiffuse, st);
 }

--- a/resources/shaders/ps_image.glsl
+++ b/resources/shaders/ps_image.glsl
@@ -2,4 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-varying vec2 vUv;
+varying vec2 vUv;                 // Location within the CSS box to draw.
+flat varying vec2 vTextureOffset; // Offset of this image into the texture atlas.
+flat varying vec2 vTextureSize;   // Size of the image in the texture atlas.

--- a/resources/shaders/ps_image.vs.glsl
+++ b/resources/shaders/ps_image.vs.glsl
@@ -5,8 +5,9 @@
 
 struct Image {
     PrimitiveInfo info;
-    vec4 local_rect;
-    vec4 st_rect;
+    vec4 local_rect;    // Size of the box we need to fill with this image.
+    vec4 st_rect;       // Location of the image texture in the texture atlas.
+    vec2 stretch_size;  // Size of the actual image.
 };
 
 layout(std140) uniform Items {
@@ -18,6 +19,7 @@ void main(void) {
     Layer layer = layers[image.info.layer_tile_part.x];
     Tile tile = tiles[image.info.layer_tile_part.y];
 
+    // Our location within the image
     vec2 local_pos = mix(image.local_rect.xy,
                          image.local_rect.xy + image.local_rect.zw,
                          aPosition.xy);
@@ -32,11 +34,10 @@ void main(void) {
 
     vec4 local_clamped_pos = layer.inv_transform * vec4(clamped_pos / uDevicePixelRatio, 0, 1);
 
-    vec2 f = (local_clamped_pos.xy - image.local_rect.xy) / image.local_rect.zw;
-
-    vUv = mix(image.st_rect.xy,
-              image.st_rect.zw,
-              f);
+    // vUv will contain how many times this image has wrapped around the image size.
+    vUv = (local_clamped_pos.xy - image.local_rect.xy) / image.stretch_size.xy;
+    vTextureSize = image.st_rect.zw - image.st_rect.xy;
+    vTextureOffset = image.st_rect.xy;
 
     vec2 final_pos = clamped_pos + tile.target_rect.xy - tile.actual_rect.xy;
 


### PR DESCRIPTION
Also, based on today's pull, even basic images don't seem to render on wr-next-next branch without this patch, but this patch worked with a couple of days ago build.
