### PR TITLE
Add support for dotted border styles

### DIFF
--- a/resources/shaders/prim_shared.glsl
+++ b/resources/shaders/prim_shared.glsl
@@ -13,6 +13,18 @@
 #define PST_BOTTOM       uint(7)
 #define PST_RIGHT        uint(8)
 
+// Border styles as defined in webrender_traits/types.rs
+#define BORDER_STYLE_NONE         uint(0)
+#define BORDER_STYLE_SOLID        uint(1)
+#define BORDER_STYLE_DOUBLE       uint(2)
+#define BORDER_STYLE_DOTTED       uint(3)
+#define BORDER_STYLE_DASHED       uint(4)
+#define BORDER_STYLE_HIDDEN       uint(5)
+#define BORDER_STYLE_GROOVE       uint(6)
+#define BORDER_STYLE_RIDGE        uint(7)
+#define BORDER_STYLE_INSET        uint(8)
+#define BORDER_STYLE_OUTSET       uint(9)
+
 struct Layer {
     mat4 transform;
     mat4 inv_transform;

--- a/resources/shaders/ps_border.fs.glsl
+++ b/resources/shaders/ps_border.fs.glsl
@@ -2,6 +2,45 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// draw a circle at position aDesiredPos with a aRadius
+vec4 drawCircle(vec2 aPixel, vec2 aDesiredPos, float aRadius, vec3 aColor) {
+  float farFromCenter = length(aDesiredPos - aPixel) - aRadius;
+  float pixelInCircle = 1.00 - clamp(farFromCenter, 0.0, 1.0);
+  return vec4(aColor, pixelInCircle);
+}
+
+void draw_dotted_border(void) {
+  // Everything here should be in device pixels.
+  float radius = 3;   // Diameter of 20
+  float diameter = radius * 2.0;
+  float circleSpacing = diameter * 2.0;
+
+  vec2 size = vec2(vBorders.z - vBorders.x, vBorders.w - vBorders.y);
+  // Get our position within this specific segment
+  vec2 position = vPos - vBorders.xy;
+
+  // Break our position into square tiles with circles in them.
+  vec2 circleCount = size / circleSpacing;
+  vec2 distBetweenCircles = size / circleCount;
+  vec2 circleCenter = distBetweenCircles / 2.0;
+
+  // Find out which tile this pixel belongs to.
+  vec2 destTile = floor(position / distBetweenCircles);
+  destTile = destTile * distBetweenCircles;
+  vec2 tileCenter = destTile + circleCenter;
+
+  // Find the position within the tile
+  vec2 positionInTile = mod(position, distBetweenCircles);
+  vec2 finalPosition = positionInTile + destTile;
+
+  vec4 white = vec4(1.0, 1.0, 1.0, 1.0);
+  vec3 black = vec3(0.0, 0.0, 0.0);
+  // See if we should draw a circle or not
+  vec4 circleColor = drawCircle(finalPosition, tileCenter, radius, black);
+
+  oFragColor = mix(white, circleColor, circleColor.a);
+}
+
 void main(void) {
 	if (vRadii.x > 0.0 &&
 		(distance(vRefPoint, vPos) > vRadii.x ||
@@ -9,9 +48,18 @@ void main(void) {
 		discard;
 	}
 
-    if (vF > 0.0) {
-        oFragColor = vColor0;
-    } else {
-        oFragColor = vColor1;
+  switch (vBorderStyle) {
+    case BORDER_STYLE_DOTTED:
+      draw_dotted_border();
+      break;
+    case BORDER_STYLE_NONE:
+    case BORDER_STYLE_SOLID:
+    {
+      float color = step(0.0, vF);
+      vec4 red = vec4(1, 0, 0, 1);
+      vec4 green = vec4(0, 1, 0, 1);
+      oFragColor = mix(green, red, color);
+      break;
     }
+  }
 }

--- a/resources/shaders/ps_border.fs.glsl
+++ b/resources/shaders/ps_border.fs.glsl
@@ -9,47 +9,24 @@ vec4 drawCircle(vec2 aPixel, vec2 aDesiredPos, float aRadius, vec3 aColor) {
   return vec4(aColor, pixelInCircle);
 }
 
-// We want to be in the center of the tile along the axis we're
-// repeating the circle but at the top for X axis and left for Y axis.
-// e.g. we only care about being equal spacing between circles for the edge we're drawing along
-// and snap the other axis to the top or left.
-vec2 adjust_dotted_padding(float radius) {
-  switch (vBorderPart) {
-    // These are the layer tile part PrimitivePart as uploaded by the tiling.rs
-    case PST_BOTTOM_RIGHT:
-    case PST_TOP_RIGHT:
-    case PST_BOTTOM_LEFT:
-    case PST_TOP_LEFT:
-      return vec2(-radius, -radius);
-    case PST_BOTTOM:
-    case PST_TOP:
-      return vec2(0, -radius);
-    case PST_LEFT:
-    case PST_RIGHT:
-      return vec2(-radius, 0);
-  }
-}
-
-vec4 draw_dotted_corner() {
-  return vec4(1, 0, 0, 1.0);
-}
-
 vec4 draw_dotted_edge() {
   // Everything here should be in device pixels.
   // We want the dot to be roughly the size of the whole border spacing
-  // 2.2 was picked because it's roughly what Firefox is using.
-  float spacing_fudge = 2.2;
   float border_spacing = min(vBorders.w, vBorders.z);
-  float radius = floor(border_spacing / spacing_fudge);
+  float radius = floor(border_spacing / 2.0);
   float diameter = radius * 2.0;
-  float circleSpacing = diameter * 2.0;
+  // The amount of space between dots. 2.2 was chosen because it looks kind of
+  // like firefox.
+  float circleSpacing = diameter * 2.2;
 
-  vec2 size = vec2(vBorders.z - vBorders.x, vBorders.w - vBorders.y);
+  vec2 size = vec2(vBorders.z, vBorders.w);
   // Get our position within this specific segment
   vec2 position = vPos - vBorders.xy;
 
   // Break our position into square tiles with circles in them.
-  vec2 circleCount = size / circleSpacing;
+  vec2 circleCount = floor(size / circleSpacing);
+  circleCount = max(circleCount, 1);
+
   vec2 distBetweenCircles = size / circleCount;
   vec2 circleCenter = distBetweenCircles / 2.0;
 
@@ -59,10 +36,6 @@ vec4 draw_dotted_edge() {
 
   // Where we want to draw the actual circle.
   vec2 tileCenter = destTile + circleCenter;
-  // Snap the tile back because we calculate the center
-  // based on the spacing but we need to make sure we have enough
-  // space to draw the actual circle.
-  tileCenter += adjust_dotted_padding(radius);
 
   // Find the position within the tile
   vec2 positionInTile = mod(position, distBetweenCircles);
@@ -83,6 +56,7 @@ void draw_dotted_border(void) {
     case PST_TOP_RIGHT:
     case PST_BOTTOM_LEFT:
     case PST_BOTTOM_RIGHT:
+      // TODO: Fix for corners with a border-radius
       oFragColor = draw_dotted_edge();
       break;
     case PST_BOTTOM:

--- a/resources/shaders/ps_border.fs.glsl
+++ b/resources/shaders/ps_border.fs.glsl
@@ -39,7 +39,7 @@ vec4 draw_dotted_edge() {
   // We want the dot to be roughly the size of the whole border spacing
   // 2.2 was picked because it's roughly what Firefox is using.
   float spacing_fudge = 2.2;
-  float border_spacing = min(vBorders.z - vBorders.x, vBorders.w - vBorders.y);
+  float border_spacing = min(vBorders.w, vBorders.z);
   float radius = floor(border_spacing / spacing_fudge);
   float diameter = radius * 2.0;
   float circleSpacing = diameter * 2.0;

--- a/resources/shaders/ps_border.glsl
+++ b/resources/shaders/ps_border.glsl
@@ -4,10 +4,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-varying float vF;
-varying vec2 vPos;
+// These two are interpolated
+varying float vF;   // This is a weighting as we get closer to the bottom right corner?
 
-flat varying vec4 vColor0;
-flat varying vec4 vColor1;
-flat varying vec4 vRadii;
+// These are not changing.
+flat varying vec4 vColor0;  // The border color
+flat varying vec4 vColor1;  // The border color
+flat varying vec4 vRadii;   // The border radius
+
+// These are in device space
+varying vec2 vPos;  // This is the clamped position of the current position.
+flat varying vec4 vBorders; // The borders
+
+// for corners, this is the beginning of the corner.
+// For the lines, this is the top left of the line.
 flat varying vec2 vRefPoint;
+flat varying int vBorderStyle;

--- a/resources/shaders/ps_border.glsl
+++ b/resources/shaders/ps_border.glsl
@@ -14,7 +14,7 @@ flat varying vec4 vRadii;   // The border radius from CSS border-radius
 
 // These are in device space
 varying vec2 vPos;  // This is the clamped position of the current position.
-flat varying vec4 vBorders; // The borders sizes.
+flat varying vec4 vBorders; // the rect of the border in (x, y, width, height) form
 
 // for corners, this is the beginning of the corner.
 // For the lines, this is the top left of the line.

--- a/resources/shaders/ps_border.glsl
+++ b/resources/shaders/ps_border.glsl
@@ -10,13 +10,14 @@ varying float vF;   // This is a weighting as we get closer to the bottom right 
 // These are not changing.
 flat varying vec4 vColor0;  // The border color
 flat varying vec4 vColor1;  // The border color
-flat varying vec4 vRadii;   // The border radius
+flat varying vec4 vRadii;   // The border radius from CSS border-radius
 
 // These are in device space
 varying vec2 vPos;  // This is the clamped position of the current position.
-flat varying vec4 vBorders; // The borders
+flat varying vec4 vBorders; // The borders sizes.
 
 // for corners, this is the beginning of the corner.
 // For the lines, this is the top left of the line.
 flat varying vec2 vRefPoint;
-flat varying int vBorderStyle;
+flat varying uint vBorderStyle;
+flat varying uint vBorderPart; // Which part of the border we're drawing.

--- a/resources/shaders/ps_border.vs.glsl
+++ b/resources/shaders/ps_border.vs.glsl
@@ -19,11 +19,15 @@ layout(std140) uniform Items {
 uint get_border_style(Border a_border, uint a_edge) {
   switch (a_edge) {
     case PST_TOP:
+    case PST_TOP_LEFT:
       return a_border.border_style_trbl.x;
+    case PST_BOTTOM_LEFT:
     case PST_LEFT:
       return a_border.border_style_trbl.z;
+    case PST_BOTTOM_RIGHT:
     case PST_BOTTOM:
       return a_border.border_style_trbl.w;
+    case PST_TOP_RIGHT:
     case PST_RIGHT:
       return a_border.border_style_trbl.y;
   }
@@ -103,7 +107,7 @@ void main(void) {
             break;
     }
 
-    vBorderStyle = get_border_style(border, border.info.layer_tile_part.z);
+    vBorderStyle = get_border_style(border, vBorderPart);
 
     // y1 - y0 is the height of the corner / line
     // x1 - x0 is the width of the corner / line.
@@ -118,5 +122,7 @@ void main(void) {
 
     // These are in device space
     vPos = clamped_pos;
-    vBorders = vec4(x0, y0, x1, y1) * uDevicePixelRatio;
+    vBorders = vec4(border.local_rect.x, border.local_rect.y,
+                    border.local_rect.x + border.local_rect.z,
+                    border.local_rect.y + border.local_rect.w) * uDevicePixelRatio;
 }

--- a/resources/shaders/ps_border.vs.glsl
+++ b/resources/shaders/ps_border.vs.glsl
@@ -9,14 +9,14 @@ struct Border {
     vec4 color0;
     vec4 color1;
     vec4 radii;
-    ivec4 border_style_trbl;
+    uvec4 border_style_trbl;
 };
 
 layout(std140) uniform Items {
     Border borders[WR_MAX_PRIM_ITEMS];
 };
 
-int get_border_style(Border a_border, uint a_edge) {
+uint get_border_style(Border a_border, uint a_edge) {
   switch (a_edge) {
     case PST_TOP:
       return a_border.border_style_trbl.x;
@@ -56,8 +56,8 @@ void main(void) {
     vRadii = border.radii;
 
     float x0, y0, x1, y1;
-    vBorderStyle = 0;
-    switch (border.info.layer_tile_part.z) {
+    vBorderPart = border.info.layer_tile_part.z;
+    switch (vBorderPart) {
         // These are the layer tile part PrimitivePart as uploaded by the tiling.rs
         case PST_TOP_LEFT:
             x0 = border.local_rect.x;

--- a/resources/shaders/ps_border.vs.glsl
+++ b/resources/shaders/ps_border.vs.glsl
@@ -123,6 +123,6 @@ void main(void) {
     // These are in device space
     vPos = clamped_pos;
     vBorders = vec4(border.local_rect.x, border.local_rect.y,
-                    border.local_rect.x + border.local_rect.z,
-                    border.local_rect.y + border.local_rect.w) * uDevicePixelRatio;
+                    border.local_rect.z,
+                    border.local_rect.w) * uDevicePixelRatio;
 }

--- a/resources/shaders/shared.glsl
+++ b/resources/shaders/shared.glsl
@@ -10,7 +10,7 @@
 
     // Uniform inputs
 	uniform mat4 uTransform;       // Orthographic projection
-    uniform float uDevicePixelRatio;
+  uniform float uDevicePixelRatio;
 
     // Attribute inputs
 	in vec3 aPosition;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This isn't really ready yet as there a couple of things left to do, especially for the corners, but it kind of works for some values. I just wanted to see if you could take a look at it and see if I'm on the right path.

Essentially in the fragment shader we figure out the spacing to draw dots and draw them. I know I still have to pass in the radius from CSS and also properly support the corners probably by calculating an ellipsis. 

Some questions I still had:

1) In the ps_border.vs.glsl, what's the vF variable supposed to do? Seems like it's weighing something but what for?
2) Should the fragment shader be doing all of this are should I be calculating the circle's location somewhere else and upload it to the GPU?

Thanks!
